### PR TITLE
Replace hc launch with hc-spin

### DIFF
--- a/.templates/app/web-app/package.json.hbs
+++ b/.templates/app/web-app/package.json.hbs
@@ -9,13 +9,14 @@
     "start": "AGENTS=2 npm run network",
     "network": "hc s clean && npm run build:happ && UI_PORT=8888 concurrently -k \"npm start -w ui\" \"npm run launch:happ\" \"holochain-playground\"",
     "test": "npm run build:happ && cargo nextest run -j 1 && npm test -w tests",
-    "launch:happ": "echo \"pass\" | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/{{app_name}}.happ --ui-port $UI_PORT network -b https://bootstrap.holo.host webrtc wss://signal.holo.host",
+    "launch:happ": "hc-spin -n $AGENTS --ui-port $UI_PORT workdir/{{app_name}}.happ",
     "package": "npm run build:zomes && sh optimize-wasms.sh && npm run package -w ui && hc web-app pack workdir --recursive",
     "build:happ": "npm run build:zomes && hc app pack workdir --recursive",
     "build:zomes": "CARGO_TARGET_DIR=target cargo build --release --target wasm32-unknown-unknown"
   },
   "devDependencies": {
     "@holochain-playground/cli": "^0.1.0",
+    "@holochain/hc-spin": "^0.200.10",
     "concurrently": "^6.2.1",
     "rimraf": "^3.0.2"
   },

--- a/.templates/module/web-app/package.json.hbs
+++ b/.templates/module/web-app/package.json.hbs
@@ -9,12 +9,13 @@
     "start": "AGENTS=2 npm run network",
     "network": "hc s clean && npm run build:happ && UI_PORT=8888 concurrently -k \"npm start -w @holochain-open-dev/{{kebab_case app_name}}\" \"npm run launch:happ\" \"holochain-playground\"",
     "test": "npm run build:happ && cargo nextest run -j 1 && npm test -w tests",
-    "launch:happ": "echo \"pass\" | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/{{app_name}}.happ --ui-port $UI_PORT network -b https://bootstrap.holo.host webrtc wss://signal.holo.host",
+    "launch:happ": "hc-spin -n $AGENTS --ui-port $UI_PORT workdir/{{app_name}}.happ",
     "build:happ": "npm run build:zomes && hc app pack workdir --recursive",
     "build:zomes": "CARGO_TARGET_DIR=target cargo build --release --target wasm32-unknown-unknown"
   },
   "devDependencies": {
     "@holochain-playground/cli": "^0.1.1",
+    "@holochain/hc-spin": "^0.200.10",
     "@storybook/addon-essentials": "^7.5.3",
     "@storybook/addon-links": "^7.5.3",
     "@storybook/blocks": "^7.5.3",


### PR DESCRIPTION
This PR looks to replace tauri based `hc launch` with electron based [`hc-spin`](https://github.com/holochain/hc-spin) which is already in use with the scaffolding tool's default templates, which provides a better developer experience and cross platform consistency