### PR TITLE
Switches to using local-services

### DIFF
--- a/templates/app/web-app/package.json.hbs
+++ b/templates/app/web-app/package.json.hbs
@@ -9,7 +9,7 @@
     "start": "AGENTS=2 npm run network",
     "network": "hc s clean && npm run build:happ && UI_PORT=8888 concurrently -k \"npm start -w ui\" \"npm run launch:happ\" \"holochain-playground\"",
     "test": "npm run build:happ && cargo nextest run -j 1 && npm test -w tests",
-    "launch:happ": "echo \"pass\" | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/{{app_name}}.happ --ui-port $UI_PORT network -b https://bootstrap.holo.host webrtc wss://signal.holo.host",
+    "launch:happ": "concurrently \"hc run-local-services --bootstrap-port $BOOTSTRAP_PORT --signal-port $SIGNAL_PORT\" \"echo pass | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/{{app_name}}.happ --ui-port $UI_PORT network -b http://127.0.0.1:\"$BOOTSTRAP_PORT\" webrtc ws://127.0.0.1:\"$SIGNAL_PORT\"\"",
     "package": "nix build .#{{snake_case app_name}} -o workdir/{{snake_case app_name}}.happ && npm run package -w ui && hc web-app pack workdir --recursive",
     "build:happ": "nix build .#{{snake_case app_name}}.meta.debug -o workdir/{{snake_case app_name}}-debug.happ"
   },

--- a/templates/module/web-app/package.json.hbs
+++ b/templates/module/web-app/package.json.hbs
@@ -9,7 +9,7 @@
     "start": "AGENTS=2 npm run network",
     "network": "hc s clean && npm run build:happ && UI_PORT=8888 concurrently -k \"npm start -w @holochain-open-dev/{{kebab_case app_name}}\" \"npm run launch:happ\" \"holochain-playground\"",
     "test": "npm run build:happ && cargo nextest run -j 1 && npm test -w tests",
-    "launch:happ": "echo \"pass\" | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/{{app_name}}.happ --ui-port $UI_PORT network -b https://bootstrap.holo.host webrtc wss://signal.holo.host",
+    "launch:happ": "concurrently \"hc run-local-services --bootstrap-port $BOOTSTRAP_PORT --signal-port $SIGNAL_PORT\" \"echo pass | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/{{app_name}}.happ --ui-port $UI_PORT network -b http://127.0.0.1:\"$BOOTSTRAP_PORT\" webrtc ws://127.0.0.1:\"$SIGNAL_PORT\"\"",
     "build:happ": "npm run build:zomes && hc app pack workdir --recursive",
     "build:zomes": "CARGO_TARGET_DIR=target cargo build --release --target wasm32-unknown-unknown"
   },


### PR DESCRIPTION
This PR switches to using hc local-services for signaling and bootstrap server to
a) ensure that development nodes do not interact with nodes on the real network
b) not put strain on the production infrastructure during development